### PR TITLE
Fix LINDAS SPARQL GUI link in data_shape.ttl

### DIFF
--- a/rdf/shapes/data_shape.ttl
+++ b/rdf/shapes/data_shape.ttl
@@ -79,7 +79,7 @@ WHERE {
 LIMIT 10
 ```
 
-To run this query, you may visit the [LINDAS SPARQL GUI](https://s.zazuko.com/3779LjG).
+To run this query, you may visit the [LINDAS SPARQL GUI](https://s.zazuko.com/23Aw5hp).
 
 However, to fully leverage the analytical capabilities of this schema, users are directed to the centralized query repository.
 A comprehensive suite of advanced SPARQL query templates, demonstrating complex relational extraction and data aggregation, is maintained within the project's source control at [https://github.com/BLV-OSAV-USAV/PSMV-RDF/tree/main/src/sparql/examples](https://github.com/BLV-OSAV-USAV/PSMV-RDF/tree/main/src/sparql/examples).


### PR DESCRIPTION
Updated the link to the LINDAS SPARQL GUI in the data shape documentation.